### PR TITLE
cpp: Fix compilation documentation

### DIFF
--- a/exploring-cpp/lesson_2_gpio/README.md
+++ b/exploring-cpp/lesson_2_gpio/README.md
@@ -26,7 +26,7 @@ Next we do another new statement called sleep. `sleep(n)` does exactly what it s
 
 Now ensure to use the proper compiler flags when you attempt to compile this program!
 
-`g++ -lmraa lesson_2.cpp -o lesson_2`
+`g++ lesson_2.cpp -o lesson_2 -lmraa`
 
 Now run the program using the following command.
 

--- a/exploring-cpp/lesson_2_gpio/lesson_2.cpp
+++ b/exploring-cpp/lesson_2_gpio/lesson_2.cpp
@@ -28,7 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 * and in this lesson, you'll learn how to access
 * a digital pin on the Joule.
 * 
-* Compile with "g++ -lmraa lesson_2.cpp -o lesson_2"
+* Compile with "g++ lesson_2.cpp -o lesson_2 -lmraa"
 */
 
 #include <csignal>  //Library from the C/++ standard libraries to allow for clean exits.

--- a/exploring-cpp/lesson_3_pwm/README.md
+++ b/exploring-cpp/lesson_3_pwm/README.md
@@ -48,7 +48,7 @@ It should cause the LED to glow brighter then dimmer through the iterations. Fin
 
 Now ensure to use the proper compiler flags when you attempt to compile this program!
 
-`g++ -lmraa lesson_3.cpp -o lesson_3`
+`g++ lesson_3.cpp -o lesson_3 -lmraa`
 
 Now run the program using the following command.
 

--- a/exploring-cpp/lesson_7_classes_and_encapsulation/README.md
+++ b/exploring-cpp/lesson_7_classes_and_encapsulation/README.md
@@ -49,7 +49,7 @@ Now we go through a series of "if then else" statements. These statements detect
 
 Now ensure to use the proper compiler flags when you attempt to compile this program!
 
-`g++ -I /usr/include/upm -lupm-i2clcd -lupm-adc121c021 -lmraa -std=c++11 lesson_7.cpp devices.cpp -o lesson_7`
+`g++ -I /usr/include/upm -std=c++11 lesson_7.cpp devices.cpp -o lesson_7 -lupm-i2clcd -lupm-adc121c021 -lmraa`
 
 Now run the program using the following command.
 

--- a/exploring-cpp/lesson_8_multithreading/README.md
+++ b/exploring-cpp/lesson_8_multithreading/README.md
@@ -16,7 +16,7 @@ We then go into our main statement. This statement creates a thread named `t1` w
 
 Now ensure to use the proper compiler flags when you attempt to compile this program!
 
-`g++ -I /usr/include/upm -lupm-i2clcd -lupm-adc121c021 -lmraa -lpthread -lboost_system  -std=c++11 lesson_8.cpp devices.cpp -o lesson_8`
+`g++ -I /usr/include/upm -std=c++11 lesson_8.cpp devices.cpp -o lesson_8 -lupm-i2clcd -lupm-adc121c021 -lmraa -lpthread -lboost_system`
 
 Now run the program using the following command.
 


### PR DESCRIPTION
Ubuntu g++/ld comes with --as-needed turned on by default.
The order in which g++ is invoked matters regarding linking.

This patch corrects it.

Signed-off-by: Thomas Ingleby <thomas.ingleby@intel.com>