### PR TITLE
Fix ISS IoT JSON file for Lesson 6

### DIFF
--- a/exploring-cpp/lesson_6_using_crow/sample.json
+++ b/exploring-cpp/lesson_6_using_crow/sample.json
@@ -5,12 +5,12 @@
 	"author": "Intel Corporation & Software Services Group",
 	"date": "2016-09-29",
 	"platform": {
-			"hwreq": [
-					"Joule board",
-				],
-			"libs": [
-					"boost"
-				],
-			"compatible": ["Joule module"]
-		}
+		"hwreq": [
+			"Joule board"
+		],
+		"libs": [
+			"boost"
+		],
+		"compatible": ["Joule module"]
+	}
 }


### PR DESCRIPTION
Lesson 6 was missing inside ISS IoT Example list due to a typo.
Also indent correctly the file.