### PR TITLE
Add info on privileges required to run samples where relevant

### DIFF
--- a/ble-scan-js/README.md
+++ b/ble-scan-js/README.md
@@ -36,6 +36,9 @@ Then plug in the LCD screen to the grove shield on the I2C connector closest to 
 ## Running the code
 You can launch this project from XDK (after first importing it from XDK IoT Edition), or run it directly on your device:
 
+When running directly on your device, please note that mraa library requires root privileges to run properly. So either
+check that you are logged in as user `root` (`whoami` command will tell you) or use `sudo` command to run this app.
+
 ```
 npm install
 node index.js

--- a/blink-led-cpp/README.md
+++ b/blink-led-cpp/README.md
@@ -4,6 +4,11 @@ g++ blink.cpp -o blink -lmraa
 ```
 
 ## How To Run
+
+Please note that mraa library requires root privileges to run properly. So either
+check that you are logged in as user `root` (`whoami` command will tell you)
+or use `sudo` command to run this example.
+
 ```
 ./blink
 ```

--- a/blink-led-js/README.md
+++ b/blink-led-js/README.md
@@ -1,4 +1,9 @@
 ## How To Run
+
+Please note that mraa library requires root privileges to run properly. So either
+check that you are logged in as user `root` (`whoami` command will tell you)
+or use `sudo` command to run this example.
+
 ```
 node blink.js
 ```

--- a/blink-led-py/README.md
+++ b/blink-led-py/README.md
@@ -1,4 +1,9 @@
 ## How To Run
+
+Please note that mraa library requires root privileges to run properly. So either
+check that you are logged in as user `root` (`whoami` command will tell you)
+or use `sudo` command to run this example.
+
 ```
 python blink.py
 ```

--- a/exploring-cpp/lesson_2_gpio/cpp/README.md
+++ b/exploring-cpp/lesson_2_gpio/cpp/README.md
@@ -28,7 +28,7 @@ Now ensure to use the proper compiler flags when you attempt to compile this pro
 
 `g++ lesson_2.cpp -o lesson_2 -lmraa`
 
-Now run the program using the following command.
+Now run the program using the following command. Please also note that mraa library requires root privileges to run properly. So either check that you are logged in as user `root` (`whoami` command will tell you) or use `sudo` command to run this example.
 
 `./lesson_2`
 

--- a/exploring-cpp/lesson_3_pwm/cpp/README.md
+++ b/exploring-cpp/lesson_3_pwm/cpp/README.md
@@ -50,7 +50,7 @@ Now ensure to use the proper compiler flags when you attempt to compile this pro
 
 `g++ lesson_3.cpp -o lesson_3 -lmraa`
 
-Now run the program using the following command.
+Now run the program using the following command. Please also note that mraa library requires root privileges to run properly. So either check that you are logged in as user `root` (`whoami` command will tell you) or use `sudo` command to run this example.
 
 `./lesson_3`
 

--- a/exploring-cpp/lesson_4_i2c/cpp/README.md
+++ b/exploring-cpp/lesson_4_i2c/cpp/README.md
@@ -81,7 +81,7 @@ Now ensure to use the proper compiler flags when you attempt to compile this pro
 
 `g++ -I /usr/include/upm -lupm-i2clcd lesson_4.cpp -o lesson_4`
 
-Now run the program using the following command.
+Now run the program using the following command. Please also note that mraa library requires root privileges to run properly. So either check that you are logged in as user `root` (`whoami` command will tell you) or use `sudo` command to run this example.
 
 `./lesson_4`
 

--- a/exploring-cpp/lesson_5_adding_sensors/cpp/README.md
+++ b/exploring-cpp/lesson_5_adding_sensors/cpp/README.md
@@ -31,7 +31,7 @@ Now ensure to use the proper compiler flags when you attempt to compile this pro
 
 `g++ -I /usr/include/upm -lupm-i2clcd -lupm-adc121c021`
 
-Now run the program using the following command.
+Now run the program using the following command. Please also note that mraa library requires root privileges to run properly. So either check that you are logged in as user `root` (`whoami` command will tell you) or use `sudo` command to run this example.
 
 `./lesson_5`
 

--- a/exploring-cpp/lesson_7_classes_and_encapsulation/cpp/README.md
+++ b/exploring-cpp/lesson_7_classes_and_encapsulation/cpp/README.md
@@ -51,7 +51,7 @@ Now ensure to use the proper compiler flags when you attempt to compile this pro
 
 `g++ -I /usr/include/upm -std=c++11 lesson_7.cpp devices.cpp -o lesson_7 -lupm-i2clcd -lupm-adc121c021 -lmraa`
 
-Now run the program using the following command.
+Now run the program using the following command. Please also note that mraa library requires root privileges to run properly. So either check that you are logged in as user `root` (`whoami` command will tell you) or use `sudo` command to run this example.
 
 `./lesson_7`
 

--- a/exploring-cpp/lesson_8_multithreading/cpp/README.md
+++ b/exploring-cpp/lesson_8_multithreading/cpp/README.md
@@ -18,7 +18,7 @@ Now ensure to use the proper compiler flags when you attempt to compile this pro
 
 `g++ -I /usr/include/upm -std=c++11 lesson_8.cpp devices.cpp -o lesson_8 -lupm-i2clcd -lupm-adc121c021 -lmraa -lpthread -lboost_system`
 
-Now run the program using the following command.
+Now run the program using the following command. Please also note that mraa library requires root privileges to run properly. So either check that you are logged in as user `root` (`whoami` command will tell you) or use `sudo` command to run this example.
 
 `./lesson_8`
 


### PR DESCRIPTION
Per feeback received on this repo from users, some of the run instructions could be enhanced with information about `root` privileges required to run them. On e.g. Ubuntu more customary way would be to use `sudo` while on Ostro the user would most likely be logged on as root already.

Currently run instructions are not providing that helpful information and therefore I'd like to add that.